### PR TITLE
 Replaced _node with relative path for compatibility with windows in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "merge"
   ],
   "scripts": {
-    "test": "istanbul test _mocha --report html -- test/*.js --reporter spec",
+    "test": "istanbul test ./node_modules/mocha/bin/_mocha --report html -- test/*.js --reporter spec",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #3 

Tested in Windows 7 and Windows 10

```
C:\Users\Robin\Documents\GitHub\gulp-merge-json>npm test

> gulp-merge-json@0.1.0 test C:\Users\Robin\Documents\GitHub\gulp-merge-json
> istanbul test ./node_modules/mocha/bin/_mocha --report html -- test/*.js --rep
orter spec



  V should combine JSON files (55ms)
  V should modify property based on input function
  V should add property based on input function
  V should delete property based on input function
  V should merge object if given as input function
  V should use supplied start object as base
  V should use supplied final object to overwrite
  V should output a node module
  V should do nothing with no files
  V should error on invalid start object
  V should error on invalid end object
  V should error in editor function
  V should error on invalid JSON
  V should error on stream

  14 passing (229ms)
```
