### PR TITLE
Show json file path on parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ module.exports = function(fileName, edit, startObj, endObj, exportModule) {
   var firstFile = null;
 
   function parseAndMerge(file) {
+    var parsed;
+
     if (file.isNull()) {
       return this.queue(file);
     }
@@ -44,7 +46,14 @@ module.exports = function(fileName, edit, startObj, endObj, exportModule) {
     }
 
     try {
-      merged = merge(merged, editFunc(JSON.parse(file.contents.toString('utf8'))));
+      parsed = JSON.parse(file.contents.toString('utf8'));
+    } catch(err) {
+      err.message = 'Error while parsing ' + file.path + ': ' + err.message;
+      return this.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+    }
+
+    try {
+      merged = merge(merged, editFunc(parsed));
     } catch (err) {
       return this.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
     }

--- a/test/main.js
+++ b/test/main.js
@@ -237,7 +237,7 @@ it('should error on invalid JSON', function(done) {
   var stream = gulp.src('test/invalid.json').pipe(merge('combined.json'));
 
   stream.on('error', function(err) {
-    err.message.should.equal('Unexpected token I');
+    err.message.should.match(/Error while parsing .+test\/invalid.json: Unexpected token I/);
 
     done();
   });


### PR DESCRIPTION
Here's a re-do of #8 with passing tests. I also removed the first-argument-as-options bit, as that needs a little more work and should be a separate PR anyway.
