### PR TITLE
Added file name as edit function parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function(fileName, edit, startObj, endObj, exportModule, concat
     }
 
     try {
-      merged = merge(merged, editFunc(parsed), concatArrays);
+      merged = merge(merged, editFunc(parsed, fileName), concatArrays);
     } catch (err) {
       return this.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
     }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function(fileName, edit, startObj, endObj, exportModule, concat
     }
 
     try {
-      merged = merge(merged, editFunc(parsed, fileName), concatArrays);
+      merged = merge(merged, editFunc(parsed, file), concatArrays);
     } catch (err) {
       return this.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
     }


### PR DESCRIPTION
Use case: let's say you have i18n resources in JSON files in folders
like /en_US, /de_DE and so on. It is convenient to put all of them in
single resource file, which can be statically linked with the rest of
application code.  To do that we you need to parse file name and put the
JSON contents in separate subtrees with locale name as a key. With this
change it's possible to pass file name to edit function for that
purpose.
